### PR TITLE
Add unique index creation

### DIFF
--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -144,6 +144,9 @@ class Migrator(object):
         for name, field in fields.items():
             field.add_to_class(model, name)
             self.ops.append(self.migrator.add_column(model._meta.db_table, field.db_column, field))
+            if field.unique:
+                self.ops.append(self.migrator.add_index(
+                    model._meta.db_table, (field.db_column,), unique=True))
         return model
 
     add_fields = add_columns


### PR DESCRIPTION
@klen, `peewee`'s migrator does not create unique index while adding _unique_ column. I suggest `peewee_migrate` to do it. 