### PR TITLE
Proposed fix for #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docs/_build
 /test.db
 /_
 /.cache
+.venv

--- a/peewee_migrate/cli.py
+++ b/peewee_migrate/cli.py
@@ -58,7 +58,7 @@ def migrate(name=None, database=None, directory=None, verbose=None, fake=False):
     router = get_router(directory, database, verbose)
     migrations = router.run(name, fake=fake)
     if migrations:
-        click.echo('Migrations are completed: %s' % ', '.join(migrations))
+        click.echo('Migrations completed: %s' % ', '.join(migrations))
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_cli(tmpdir):
     result = runner.invoke(cli, [
         'migrate', '--directory=%s' % tmpdir, '--database=sqlite:///:memory:'])
     assert result.exit_code == 0
-    assert 'Migrations are completed: 001_test' in result.output
+    assert 'Migrations completed: 001_test' in result.output
 
     result = runner.invoke(cli, [
         'rollback', '--directory=%s' % tmpdir, '--database=sqlite:///:memory:', '001_test'])


### PR DESCRIPTION
This fix isn't very elegant, I'm sure you can come up with something better. The only reason I didn't just use __name__ is that it was possible that you could reference a model before it is defined. One possible way to implement this would be to order the model creation based on it's dependencies, I believe peewee has a function that does this (sort_models_topologically) but I'm not sure if that would work in  all cases. Another approach might be lazy local imports instead of lazily importing the original models. I also had to change the related_name because it was resulting in conflicts given the mixing of migration and original models.