### PR TITLE
Do not fail on unicode string during automatic migration generation

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -46,7 +46,7 @@ class BaseRouter(object):
         """Create a migration."""
         migrate = rollback = ''
         if auto:
-            if isinstance(auto, str):
+            if isinstance(auto, basestring):
                 try:
                     auto = import_module(auto)
                 except ImportError:


### PR DESCRIPTION
isinstance(foo, str) does not work when the string is unicode. This fix has
been taken from https://mail.python.org/pipermail/winnipeg/2007-August/000237.html. There are no
instruction for running tests, and I could not figure it out myself.