### PR TITLE
Make --fake CLI option a flag

### DIFF
--- a/peewee_migrate/cli.py
+++ b/peewee_migrate/cli.py
@@ -49,7 +49,7 @@ def cli():
 @click.option('--name', default=None, help="Select migration")
 @click.option('--database', default=None, help="Database connection")
 @click.option('--directory', default='migrations', help="Directory where migrations are stored")
-@click.option('--fake', default=False, help=("Run migration as fake."))
+@click.option('--fake', is_flag=True, default=False, help=("Run migration as fake."))
 @click.option('-v', '--verbose', count=True)
 def migrate(name=None, database=None, directory=None, verbose=None, fake=False):
     """Migrate database."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,12 @@ def test_cli(tmpdir):
     assert result.exit_code == 0
 
     result = runner.invoke(cli, [
+        'migrate', '--directory=%s' % tmpdir, '--database=sqlite:///:memory:', '-v', '--fake'])
+    assert result.exit_code == 0
+    assert 'Migrations completed: 001_test' in result.output
+    assert 'add_column' not in result.output
+
+    result = runner.invoke(cli, [
         'migrate', '--directory=%s' % tmpdir, '--database=sqlite:///:memory:'])
     assert result.exit_code == 0
     assert 'Migrations completed: 001_test' in result.output


### PR DESCRIPTION
This means you can use:

    pw_migrate migrate --fake --database=...

Instead of 

    pw_migrate migrate --fake text_value_here --database=...

The text value passed for `--fake` was used as a truthy value for [`BaseRouter.run`](https://github.com/klen/peewee_migrate/blob/cbcc6cbdc92348377f74b95cf8c48bd10f9aa37b/peewee_migrate/router.py#L152). Making `--fake` a flag means `True` is passed to `BaseRouter.run` rather than the text value given on the command-line.