### PR TITLE
Add PostgresExtDatabase fields to auto cli

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -76,11 +76,32 @@ class Column(VanilaColumn):
 
     def get_field(self, space=' '):
         # Generate the field definition for this column.
+        postgres_ext_fields = [
+            'ArrayField',
+            'HStoreField',
+            'IntervalField',
+            'JSONField',
+            'BinaryJSONField',
+            'TSVectorField',
+            'DateTimeTZField'
+        ]
+
         field_params = self.get_field_parameters()
         param_str = ', '.join('%s=%s' % (k, v)
                               for k, v in sorted(field_params.items()))
-        return '{name}{space}={space}pw.{classname}({params})'.format(
-            name=self.name, space=space, classname=self.field_class.__name__, params=param_str)
+
+        if self.field_class.__name__ in postgres_ext_fields:
+            module = 'pw_pext'
+        else:
+            module = 'pw'
+
+        return '{name}{space}={space}{module}.{classname}({params})'.format(
+            name=self.name,
+            space=space,
+            module=module,
+            classname=self.field_class.__name__,
+            params=param_str
+        )
 
 
 def diff_one(model1, model2, **kwargs):

--- a/peewee_migrate/template.txt
+++ b/peewee_migrate/template.txt
@@ -23,6 +23,7 @@ Some examples (model - class or model name)::
 
 import datetime as dt
 import peewee as pw
+import playhouse.postgres_ext as pw_pext
 
 
 def migrate(migrator, database, fake=False, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cached_property     >= 1.3.0
 click               >= 6.6
 mock                >= 2.0.0
 peewee              >= 2.10.1
+psycopg2            >= 2.7.3.1

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,7 +1,9 @@
 import os.path as path
 
 import peewee as pw
-
+from playhouse.postgres_ext import (ArrayField, BinaryJSONField, DateTimeTZField,
+                                    HStoreField, IntervalField, JSONField,
+                                    TSVectorField)
 
 CURDIR = path.abspath(path.dirname(__file__))
 
@@ -38,3 +40,23 @@ def test_auto():
     assert changes[-3] == "migrator.drop_not_null('person', 'last_name')"
     assert changes[-2] == "migrator.drop_index('person', 'last_name')"
     assert changes[-1] == "migrator.add_index('person', 'last_name', unique=True)"
+
+
+
+def test_auto_postgresext():
+    from peewee_migrate.auto import diff_one, diff_many, model_to_code
+    from peewee_migrate.cli import get_router
+
+    class Object(pw.Model):
+        array_field = ArrayField()
+        binary_json_field = BinaryJSONField()
+        dattime_tz_field = DateTimeTZField()
+        hstore_field = HStoreField()
+        interval_field = IntervalField()
+        json_field = JSONField()
+        ts_vector_field = TSVectorField()
+
+    code = model_to_code(Object)
+    assert code
+    assert "json_field = pw_pext.JSONField()" in code
+    assert "hstore_field = pw_pext.HStoreField(index=True)" in code


### PR DESCRIPTION
This pr adds support for the postgres extension fields like JSONField in the auto cli. Currently the program will insert `pw.JSONField` which does not work. This pr makes all the supported fields `pw_pext.JSONField()` and imports `import playhouse.postgres_ext as pw_pext`.

Issue: https://github.com/klen/peewee_migrate/issues/17 