### PR TITLE
Help Wanted: Peewee 3 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: python
 python: 2.7
 
 env:
-- TOXENV=py27
-- TOXENV=py34
+- TOXENV=py27-peewee2
+- TOXENV=py27-peewee3
+- TOXENV=py34-peewee2
+- TOXENV=py34-peewee3
 - TOXENV=cov
 
 branches:

--- a/peewee_migrate/compat.py
+++ b/peewee_migrate/compat.py
@@ -188,4 +188,35 @@ except ImportError:
         __import__(name)
         return sys.modules[name]
 
+# Peewee 2 -> 3 compatibility functions
+try:
+    from peewee import Clause
+    IS_PEEWEE_2 = True
+except ImportError:
+    IS_PEEWEE_2 = False
+    # @TODO This is not how the clause works at all
+    def Clause(*parts):
+        return ' '.join([part.sql for part in parts])
+
+
+def get_table_name(model):
+    try:
+        return model._meta.table_name
+    except AttributeError:
+        return model._meta.db_table
+
+
+def get_field_name(field):
+    try:
+        return field.column_name
+    except AttributeError:
+        return field.db_column
+
+
+def add_field_to_class(field, model, name):
+    try:
+        field.add_to_class(model, name)
+    except AttributeError:
+        field.bind(model, name)
+
 # pylama:ignore=W,E731,C901

--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,0 +1,8 @@
+-e .
+
+cached_property     >= 1.3.0
+click               >= 6.6
+mock                >= 2.0.0
+ipdb==0.10.3
+pytest==3.2.3
+psycopg2            >= 2.7.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,cov
+envlist={py27,py34,py36}-{peewee2,peewee3},cov
 
 [pytest]
 addopts = -sx
@@ -11,8 +11,11 @@ ignore=D,C0111,C1001,W0110,W0212,W0223,R
 ignore=W0611,W0612
 
 [testenv]
-commands=py.test
-deps = -rrequirements-tests.txt
+commands=py.test []
+deps =
+    -rrequirements-tox.txt
+    peewee2: peewee>=2.10,<3.0
+    peewee3: peewee>=3.0.0
 
 [testenv:cov]
 deps =


### PR DESCRIPTION
* Add wrappers to get renamed fields in Peewee 3
* Start trying to get database compilation and Clause support for Peewee 3
* Add tox support for Peewee 2 and 3

## Help Wanted

Peewee recently released version 3 which had a bunch of backwards incompatible changes from version 2. Unfortunately, some of these changes are causing errors in peewee_migrate. I was able to start addressing some low hanging fruit, like attributes being renamed, through compatibility helper functions. I am running into some problems around the fact that Peewee completely rewrote (and in some instances, removed) core functionality around query compilation, which is used for some of the more complex operations in this library.

I have gone ahead and added `@TODO: (peewee-3-compat)` around some of the code that broke in this major version change. I'm going to try to figure out how to upgrade some of this logic, but I'll take any help anyone can offer on this.

There is a method in `playhouse.migrate` that matches one in this library and I suspect that we'll need to rewrite some of these operations in this style https://github.com/coleifer/peewee/blob/master/playhouse/migrate.py#L207-L221