### PR TITLE
Improved migration error handling

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -153,9 +153,8 @@ class BaseRouter(object):
 
         except Exception as exc:
             self.database.rollback()
-            self.logger.exception(exc)
             operation = 'Migration' if not downgrade else 'Rollback'
-            self.logger.error('%s failed: %s', operation, name)
+            self.logger.exception('%s failed: %s', operation, name)
             raise
 
     def run(self, name=None, fake=False):


### PR DESCRIPTION
Instead of two log messages, log single one, containing both error message and traceback.

This fix is especially useful for loggers that log to some database, not plain text file. This way, link between traceback and error message is not lost.