### PR TITLE
fix index=True and unique=True

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -226,7 +226,8 @@ def field_to_params(field, **kwargs):
             isinstance(field.default, Hashable):
         params['default'] = field.default
 
-    params['index'] = field.index, field.unique
+    index = field.index and not field.unique # Correct case where index and unique are both True
+    params['index'] = index, field.unique
 
     params.pop('backref', None)  # Ignore backref
     return params


### PR DESCRIPTION
```python
class User(Model):
    email = CharField(max_length=50, index=True, unique=True)
```

Causes the migrator to always find an index difference.  The mocked models use field.index = not field.unique, so index will always be false.  An easy fix is to remove index=True in the model definition, but this PR should prevent the issue from occurring in the first place. 

Example excess migration:
```python
def migrate(migrator, database, fake=False, **kwargs):
    """Write your migrations here."""
    migrator.drop_index('user', 'email')
    migrator.add_index('user', 'email', unique=True)
```