### PR TITLE
fix issue #77 by importing SQL explicitly

### DIFF
--- a/peewee_migrate/template.txt
+++ b/peewee_migrate/template.txt
@@ -23,6 +23,7 @@ Some examples (model - class or model name)::
 
 import datetime as dt
 import peewee as pw
+from peewee import SQL
 
 try:
     import playhouse.postgres_ext as pw_pext


### PR DESCRIPTION
The --auto switch produces code that is not working for fields with extra arguments like `default`. The output looks like this:

     length_mm = pw.FloatField(constraints=[SQL("DEFAULT 0.0")])

`SQL` has not been imported in the template so I fixed this by adding the import to the template.