### PR TITLE
Add quotation marks around default values of CharFields

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -51,7 +51,10 @@ class Column(VanilaColumn):
             unique=field.unique, extra_parameters={}
         )
         if field.default is not None and not callable(field.default):
-            self.default = field.default
+            if (isinstance(field, pw._StringField) and
+                    isinstance(field.default, pw.text_type) and not
+                    field.default.startswith("'")):
+                self.default = "'{0}'".format(field.default)
 
         if self.field_class in FIELD_TO_PARAMS:
             self.extra_parameters.update(FIELD_TO_PARAMS[self.field_class](field))

--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -55,6 +55,8 @@ class Column(VanilaColumn):
                     isinstance(field.default, pw.text_type) and not
                     field.default.startswith("'")):
                 self.default = "'{0}'".format(field.default)
+            else:
+                self.default = "{0}".format(field.default)
 
         if self.field_class in FIELD_TO_PARAMS:
             self.extra_parameters.update(FIELD_TO_PARAMS[self.field_class](field))

--- a/peewee_migrate/template.txt
+++ b/peewee_migrate/template.txt
@@ -23,6 +23,7 @@ Some examples (model - class or model name)::
 
 import datetime as dt
 import peewee as pw
+from peewee import SQL
 
 try:
     import playhouse.postgres_ext as pw_pext


### PR DESCRIPTION
This fixes #96 by adding quotation marks around the default values of character fields.