### PR TITLE
include meta indexes attribute to migration

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -174,7 +174,7 @@ def model_to_code(Model, **kwargs):
         (INDENT + 'schema = "%s"' % Model._meta.schema) if Model._meta.schema else '',
         (INDENT + 'primary_key = pw.CompositeKey{0}'.format(Model._meta.primary_key.field_names))
         if isinstance(Model._meta.primary_key, pw.CompositeKey) else '',
-        (INDENT + 'indexes = "%s' % Model._meta.indexes) if Model._meta.indexes else '',
+        (INDENT + 'indexes = %s' % Model._meta.indexes) if Model._meta.indexes else '',
     ])
 
     return template.format(classname=Model.__name__, fields=fields, meta=meta)

--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -174,6 +174,7 @@ def model_to_code(Model, **kwargs):
         (INDENT + 'schema = "%s"' % Model._meta.schema) if Model._meta.schema else '',
         (INDENT + 'primary_key = pw.CompositeKey{0}'.format(Model._meta.primary_key.field_names))
         if isinstance(Model._meta.primary_key, pw.CompositeKey) else '',
+        (INDENT + 'indexes = "%s' % Model._meta.indexes) if Model._meta.indexes else '',
     ])
 
     return template.format(classname=Model.__name__, fields=fields, meta=meta)

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -78,3 +78,20 @@ def test_auto_postgresext():
     assert code
     assert "json_field = pw_pext.JSONField()" in code
     assert "hstore_field = pw_pext.HStoreField(index=True)" in code
+
+
+def test_auto_multi_column_index():
+    from peewee_migrate.auto import model_to_code
+
+    class Object(pw.Model):
+        first_name = pw.CharField()
+        last_name = pw.CharField()
+
+        class Meta:
+            indexes = (
+                (('first_name', 'last_name'), True),
+            )
+
+    code = model_to_code(Object)
+    assert code
+    assert "indexes =" in code


### PR DESCRIPTION
Hi,

First thing, thank you for your work :)
I have noticed that when I define a model with multi column unique key:
```
    class Object(pw.Model):
        first_name = pw.CharField()
        last_name = pw.CharField()

        class Meta:
            indexes = (
                (('first_name', 'last_name'), True),
            )
```
and if I use `auto` generate feature: `pw_migrate create --auto .....`, so in generated migration file `indexes` attribute is missing in `Meta` class.

So this PR is about to add this feature to `peewee_migrate`.