### PR TITLE
Fix postgres change column

### DIFF
--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -77,10 +77,10 @@ class PostgresqlMigrator(SchemaMigrator, PgM):
 
     def alter_change_column(self, table, column_name, field):
         """Support change columns."""
-        clause = super(PostgresqlMigrator, self).alter_change_column(table, column_name, field)
-        clause._sql.insert(-1, 'TYPE')
-        clause._sql.insert(-1, ' ')
-        return clause
+        context = super(PostgresqlMigrator, self).alter_change_column(table, column_name, field)
+        context._sql.insert(-1, 'TYPE')
+        context._sql.insert(-1, ' ')
+        return context
 
 
 class SqliteMigrator(SchemaMigrator, SqM):

--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -78,8 +78,8 @@ class PostgresqlMigrator(SchemaMigrator, PgM):
     def alter_change_column(self, table, column_name, field):
         """Support change columns."""
         clause = super(PostgresqlMigrator, self).alter_change_column(table, column_name, field)
-        field_clause = clause.nodes[-1]
-        field_clause.nodes.insert(1, SQL('TYPE'))
+        clause._sql.insert(-1, 'TYPE')
+        clause._sql.insert(-1, ' ')
         return clause
 
 

--- a/tests/mocks/postgres.py
+++ b/tests/mocks/postgres.py
@@ -1,0 +1,20 @@
+
+from psycopg2.extensions import connection, cursor
+
+class MockConnection(connection):
+    def __init__(self, *args, **kwargs):
+        self._cursor = MockCursor()
+    def cursor(self, *args, **kwargs):
+        return self._cursor
+
+class MockCursor(cursor):
+    def __init__(self, *args, **kwargs):
+        self.queries = []
+    def execute(self, query, *args, **kwargs):
+        self.queries.append(query)
+    def fetchall(self, *args, **kwargs):
+        return []
+    def fetchone(self, *args, **kwargs):
+        return None
+
+__all__ = ["MockConnection"]

--- a/tests/mocks/postgres.py
+++ b/tests/mocks/postgres.py
@@ -1,4 +1,3 @@
-
 from psycopg2.extensions import connection, cursor
 
 class MockConnection(connection):


### PR DESCRIPTION
When attempting to apply a postgres migration, alter column would fail. This is because the object returned by `alter_change_column` is expected to be a `Clause`, but instead is a `Context` object.  It looks like this may have been something that changed between Peewee 2 and 3.

Also, added a postgres migrator test.