### PR TITLE
Fixed issue where the curdir wasn't in the path so the import wouldn'…

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -74,6 +74,8 @@ class BaseRouter(object):
         """
         migrate = rollback = ''
         if auto:
+            # Need to append the CURDIR to the path for import to work.
+            sys.path.append(CURDIR)
             try:
                 modules = [auto]
                 if isinstance(auto, bool):


### PR DESCRIPTION
I have been running into the issue where I want a migration to be auto generated for me. 
My project layout is as such:

```
auth/
-auth/
-- __init__.py
--migrations.py
-migrations/
-poetry.lock
```

I am CDed into the `auth/` dir and run this command:
```
pw_migrate create --database=${DB_URL} --auto --auto-source=auth  -v initial
```

And it always comes back as 
```
Can't import models module: auth
```

Ends up, when I placed a pdb in router.py in the `create` method on the `BaseRouter` object.. the CURDIR is not in the path. Thus I just added it and now it works. Plus I ran tox to ensure that all tests continued to pass.

Hopeful we can get this change into 1.0.0 so this issue won't plague others. 

Context:
I am using python 3.7 in an virtualenv with poetry as my package manager. I am working on writing an AWS Lambda function with the serverless framework and I want to use peewee as my orm, but I needed a package to handle migrations for me. This package is the Bees Knees :D! Thank you friends.
