### PR TITLE
Return useful error when there is an issue with the underlying developers imports.

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -85,8 +85,7 @@ class BaseRouter(object):
                 models = [m for module in modules for m in load_models(module)]
 
             except ImportError as e:
-                if not auto:
-                    return self.logger.error(e.msg)
+                self.logger.error(e.msg)
                 return self.logger.error("Can't import models module: %s", auto)
 
             if self.ignore:

--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -84,7 +84,9 @@ class BaseRouter(object):
 
                 models = [m for module in modules for m in load_models(module)]
 
-            except ImportError:
+            except ImportError as e:
+                if not auto:
+                    return self.logger.error(e.msg)
                 return self.logger.error("Can't import models module: %s", auto)
 
             if self.ignore:


### PR DESCRIPTION
Sometimes we create migrations for local development databases but someone adds an invalid import, in this situation the real error is hidden from the developer as only `Can't import models module: True` is returned instead of the real issue: `No module named 'peewee_extra_fields'`. This PR is meant to help prevent others from having to download this library and place it in the editable mode with a debugger in it.. just to find out the library works as expected.