### PR TITLE
Fixes an issue with migrator.rename_table(..)

### DIFF
--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -273,10 +273,11 @@ class Migrator(object):
     @get_model
     def rename_table(self, model, new_name):
         """Rename table in database."""
+        old_name = model._meta.table_name
         del self.orm[model._meta.table_name]
         model._meta.table_name = new_name
         self.orm[model._meta.table_name] = model
-        self.ops.append(self.migrator.rename_table(model._meta.table_name, new_name))
+        self.ops.append(self.migrator.rename_table(old_name, new_name))
         return model
 
     @get_model


### PR DESCRIPTION
The function rename_table call self.migrator.rename_table(model, model) with the same model names:

def rename_table(self, model, **new_name**):
&nbsp;&nbsp;&nbsp;&nbsp;"""Rename table in database."""
&nbsp;&nbsp;&nbsp;&nbsp;del self.orm[model._meta.table_name]
&nbsp;&nbsp;&nbsp;&nbsp;**model._meta.table_name** = **new_name**
&nbsp;&nbsp;&nbsp;&nbsp;self.orm[model._meta.table_name] = model
&nbsp;&nbsp;&nbsp;&nbsp;self.ops.append(self.migrator.rename_table(**model._meta.table_name, new_name**))
&nbsp;&nbsp;&nbsp;&nbsp;return model