### PR TITLE
No more twice module importing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,10 +2,16 @@
 Credits
 =======
 
+Initial Author
+--------------
+
+* Kirill Klenov <horneds@gmail.com>
+
+
 Development Lead
 ----------------
 
-* Kirill Klenov <horneds@gmail.com>
+* spumer
 
 Contributors
 ------------

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,1 +1,2 @@
-Simple migration engine for Peewee 
+Simple migration engine for Peewee
+Fork of klen/peewee_migrate

--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,24 @@
-Peewee Migrate
-##############
+Peewee Migrate 2
+################
 
 .. _description:
 
-Peewee Migrate -- A simple migration engine for Peewee
+Peewee Migrate 2 -- A simple migration engine for Peewee
+
 
 .. _badges:
 
-.. image:: http://img.shields.io/travis/klen/peewee_migrate.svg?style=flat-square
-    :target: http://travis-ci.org/klen/peewee_migrate
+.. image:: https://travis-ci.org/spumer/peewee_migrate.svg
+    :target: http://travis-ci.org/spumer/peewee_migrate
     :alt: Build Status
 
-.. image:: http://img.shields.io/coveralls/klen/peewee_migrate.svg?style=flat-square
-    :target: https://coveralls.io/r/klen/pewee_migrate
+
+.. image:: https://coveralls.io/repos/github/spumer/peewee_migrate/badge.svg
+    :target: https://coveralls.io/github/spumer/peewee_migrate
     :alt: Coverals
 
-.. image:: http://img.shields.io/pypi/v/peewee_migrate.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/peewee_migrate
+.. image:: http://img.shields.io/pypi/v/peewee_migrate2.svg?style=flat-square
+    :target: https://pypi.python.org/pypi/peewee_migrate2
     :alt: Version
 
 .. _contents:
@@ -24,6 +26,19 @@ Peewee Migrate -- A simple migration engine for Peewee
 .. contents::
 
 .. _requirements:
+
+
+Why Fork?
+=========
+
+It's a fork of original https://github.com/klen/peewee_migrate. Thank ``klen`` for that!
+
+But ``klen`` don't support project for a long time.
+
+To fix critical project was forked and development continued.
+
+All previous compatibilities will be preserved.
+
 
 Requirements
 =============

--- a/peewee_migrate/__init__.py
+++ b/peewee_migrate/__init__.py
@@ -11,7 +11,7 @@ import peewee as pw
 # Package information
 # ===================
 
-__version__ = "1.1.6"
+__version__ = "1.2.0"
 __project__ = "peewee_migrate2"
 __author__ = "spumer, Kirill Klenov"
 __license__ = "BSD"

--- a/peewee_migrate/__init__.py
+++ b/peewee_migrate/__init__.py
@@ -11,7 +11,7 @@ import peewee as pw
 # Package information
 # ===================
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __project__ = "peewee_migrate2"
 __author__ = "spumer, Kirill Klenov"
 __license__ = "BSD"

--- a/peewee_migrate/__init__.py
+++ b/peewee_migrate/__init__.py
@@ -12,8 +12,8 @@ import peewee as pw
 # ===================
 
 __version__ = "1.1.6"
-__project__ = "peewee_migrate"
-__author__ = "Kirill Klenov <horneds@gmail.com>"
+__project__ = "peewee_migrate2"
+__author__ = "spumer, Kirill Klenov"
 __license__ = "BSD"
 
 

--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -270,13 +270,13 @@ class Migrator(object):
 
     rename_field = rename_column
 
-    @get_model
     def rename_table(self, model, new_name):
         """Rename table in database."""
+        old_name = model._meta.table_name
         del self.orm[model._meta.table_name]
         model._meta.table_name = new_name
         self.orm[model._meta.table_name] = model
-        self.ops.append(self.migrator.rename_table(model._meta.table_name, new_name))
+        self.ops.append(self.migrator.rename_table(old_name, new_name))
         return model
 
     @get_model

--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -279,16 +279,20 @@ def _import_submodules(package, passed=UNDEFINED):
         package = import_module(package)
 
     modules = []
-    if set(package.__path__) & passed:
-        return modules
-
-    passed |= set(package.__path__)
 
     for loader, name, is_pkg in pkgutil.walk_packages(package.__path__, package.__name__ + '.'):
-        module = loader.find_module(name).load_module(name)
+        if name in passed:
+            continue
+        passed.add(name)
+
+        module = sys.modules.get(name)
+        if module is None:
+            module = loader.find_module(name).load_module(name)
+
         modules.append(module)
         if is_pkg:
-            modules += _import_submodules(module)
+            modules += _import_submodules(module, passed=passed)
+
     return modules
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
-current_version = 1.1.6
+current_version = 1.2.0
 files = peewee_migrate/__init__.py
 tag = True
 tag_name = {new_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
-current_version = 1.2.0
+current_version = 1.2.1
 files = peewee_migrate/__init__.py
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,8 @@ setup(
     platforms=('Any'),
     keywords = "django flask sqlalchemy testing mock stub mongoengine data".split(), # noqa
 
-    author='Kirill Klenov',
-    author_email='horneds@gmail.com',
-    url='https://github.com/klen/peewee_migrate',
+    author='spumer, Kirill Klenov',
+    url='https://github.com/spumer/peewee_migrate',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     name=_project,
     version=_version,
     license=_license,
-    description=_read('DESCRIPTION'),
     long_description=_read('README.rst'),
     platforms=('Any'),
     keywords = "django flask sqlalchemy testing mock stub mongoengine data".split(), # noqa

--- a/tests/test_autodiscover/some_folder_four/__init__.py
+++ b/tests/test_autodiscover/some_folder_four/__init__.py
@@ -1,0 +1,4 @@
+from . import module
+
+# guarantee auto-importing submodules when access to package
+__all__ = ['module']

--- a/tests/test_autodiscover/some_folder_four/module.py
+++ b/tests/test_autodiscover/some_folder_four/module.py
@@ -1,0 +1,4 @@
+from .references_holder import add_ref
+
+
+add_ref('single value')

--- a/tests/test_autodiscover/some_folder_four/references_holder.py
+++ b/tests/test_autodiscover/some_folder_four/references_holder.py
@@ -1,0 +1,7 @@
+_REFS = set()
+
+
+def add_ref(value):
+    if value in _REFS:
+        raise ValueError('Duplicate reference %r' % value)
+    _REFS.add(value)

--- a/tests/test_autodiscover/test_autodiscover.py
+++ b/tests/test_autodiscover/test_autodiscover.py
@@ -2,7 +2,7 @@ from peewee_migrate.router import load_models
 
 
 def fqn(obj):
-    return obj.__module__ + '.' + obj.__qualname__
+    return obj.__module__ + '.' + obj.__name__
 
 
 def test_autodiscover_two_files_with_models():

--- a/tests/test_autodiscover/test_autodiscover.py
+++ b/tests/test_autodiscover/test_autodiscover.py
@@ -1,6 +1,22 @@
 from peewee_migrate.router import load_models
 
 
+def fqn(obj):
+    return obj.__module__ + '.' + obj.__qualname__
+
+
 def test_autodiscover_two_files_with_models():
     result = load_models('tests.test_autodiscover')
-    assert len(result) == 12
+    result = {fqn(x) for x in result}
+    assert result == {
+        'tests.test_autodiscover.some_folder_one.another_models.Object1',
+        'tests.test_autodiscover.some_folder_one.another_models.Object2',
+        'tests.test_autodiscover.some_folder_one.one_models.Object3',
+        'tests.test_autodiscover.some_folder_three.base_model_s.Model1',
+        'tests.test_autodiscover.some_folder_three.nested_referenced_model_s.Model3',
+        'tests.test_autodiscover.some_folder_three.referenced_model_s.Model2',
+        'tests.test_autodiscover.some_folder_two.another_model.Object1',
+        'tests.test_autodiscover.some_folder_two.another_model.Object2',
+        'tests.test_autodiscover.some_folder_two.base_model.BaseModel',
+        'tests.test_autodiscover.some_folder_two.one_model.Object3',
+    }

--- a/tests/test_autodiscover/test_autodiscover.py
+++ b/tests/test_autodiscover/test_autodiscover.py
@@ -7,8 +7,8 @@ def fqn(obj):
 
 def test_autodiscover_two_files_with_models():
     result = load_models('tests.test_autodiscover')
-    result = {fqn(x) for x in result}
-    assert result == {
+    result = sorted(fqn(x) for x in result)
+    assert result == sorted([
         'tests.test_autodiscover.some_folder_one.another_models.Object1',
         'tests.test_autodiscover.some_folder_one.another_models.Object2',
         'tests.test_autodiscover.some_folder_one.one_models.Object3',
@@ -19,4 +19,4 @@ def test_autodiscover_two_files_with_models():
         'tests.test_autodiscover.some_folder_two.another_model.Object2',
         'tests.test_autodiscover.some_folder_two.base_model.BaseModel',
         'tests.test_autodiscover.some_folder_two.one_model.Object3',
-    }
+    ])


### PR DESCRIPTION
Twice importing broke Pydantic behaviour when register model validator:
https://github.com/samuelcolvin/pydantic/blob/v1.2/pydantic/class_validators.py#L136
Also broke firebase_admin package when use `.initialize_app()`
https://github.com/firebase/firebase-admin-python/blob/24e5ad42e048db122c2357f110aee358f33a3480/firebase_admin/__init__.py#L72


This also described in commit message.