### PR TITLE
fix applying migrations by name

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -194,10 +194,11 @@ class BaseRouter(object):
 
         migrator = self.migrator
         for mname in diff:
+            if name and name != mname:
+                break
+
             self.run_one(mname, migrator, fake=fake, force=fake)
             done.append(mname)
-            if name and name == mname:
-                break
 
         return done
 


### PR DESCRIPTION
Fixes #

Changes is in this PR
- Fixed a bug when using a migration with the same name, the version is constantly promoted regardless of the specified name

