### PR TITLE
fix auto-source default

### DIFF
--- a/peewee_migrate/cli.py
+++ b/peewee_migrate/cli.py
@@ -70,7 +70,7 @@ def migrate(name=None, database=None, directory=None, verbose=None, fake=False):
 @click.option('--auto', default=False, is_flag=True, help=(
     "Scan sources and create db migrations automatically. "
     "Supports autodiscovery."))
-@click.option('--auto-source', default=False, help=(
+@click.option('--auto-source', default=None, help=(
     "Set to python module path for changes autoscan (e.g. 'package.models'). "
     "Current directory will be recursively scanned by default."))
 @click.option('--database', default=None, help="Database connection")


### PR DESCRIPTION
Fixes issue with `auto-source` param likely caused by click guessing its type from the default value.
If default is a bool, click will expect `BOOLEAN` and will not allow a string, which is what we need.

Changes is in this PR
- change default value of `auto-source` param to None so that click infers `TEXT`. 

cc/ @klen
