### PR TITLE
Fix self-referencing foreign keys

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -67,7 +67,11 @@ class Column(VanilaColumn):
         if isinstance(field, pw.ForeignKeyField):
             self.to_field = field.rel_field.name
             self.related_name = field.backref
-            self.rel_model = "migrator.orm['%s']" % field.rel_model._meta.table_name
+            self.rel_model = (
+                "'self'"
+                if field.rel_model == field.model
+                else "migrator.orm['%s']" % field.rel_model._meta.table_name
+            )
 
     def get_field(self, space=' '):
         # Generate the field definition for this column.

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -105,3 +105,18 @@ def test_self_referencing_foreign_key_on_model_create():
 
     code = field_to_code(Employee.manager)
     assert "model='self'" in code
+
+
+def test_self_referencing_foreign_key_on_field_added():
+    from peewee_migrate.auto import diff_one
+
+    class Employee(pw.Model):
+        name = pw.CharField()
+
+    class EmployeeNew(pw.Model):
+        name = pw.CharField()
+        manager = pw.ForeignKeyField("self")
+
+    changes = diff_one(EmployeeNew, Employee)
+    assert "migrator.add_fields" in changes[0]
+    assert "model='self'" in changes[0]

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -95,3 +95,13 @@ def test_auto_multi_column_index():
     code = model_to_code(Object)
     assert code
     assert "indexes = [(('first_name', 'last_name'), True)]" in code
+
+
+def test_self_referencing_foreign_key_on_model_create():
+    from peewee_migrate.auto import field_to_code
+
+    class Employee(pw.Model):
+        manager = pw.ForeignKeyField("self")
+
+    code = field_to_code(Employee.manager)
+    assert "model='self'" in code


### PR DESCRIPTION
Fixes #202 

With this PR, auto migrations will work correctly for models with self-referencing foreign keys. Right now, applying the migration fails because of `KeyError` (model is not yet in `migrator.orm` dict)

cc/ @klen
