### PR TITLE
fix: do not read migration template on module import (read it later right before migration)

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -32,8 +32,6 @@ CLEAN_RE: t.Pattern = re.compile(r'\s+$', re.M)
 CURDIR: Path = Path.cwd()
 DEFAULT_MIGRATE_DIR: Path = CURDIR / 'migrations'
 VOID: t.Callable = lambda m, d: None # noqa
-with open(Path(__file__).parent / 'template.txt') as fp:
-    MIGRATE_TEMPLATE: str = fp.read()
 
 
 class BaseRouter(object):
@@ -249,11 +247,14 @@ class Router(BaseRouter):
         if num is None:
             num = len(self.todo)
 
+        with open(Path(__file__).parent / 'template.txt') as fp:
+            migrate_template: str = fp.read()
+
         name = '{:03}_'.format(num + 1) + name
         filename = name + '.py'
         path = os.path.join(self.migrate_dir, filename)
         with open(path, 'w') as f:
-            f.write(MIGRATE_TEMPLATE.format(migrate=migrate, rollback=rollback, name=filename))
+            f.write(migrate_template.format(migrate=migrate, rollback=rollback, name=filename))
 
         return name
 


### PR DESCRIPTION
hello,

this patch removes the potentially crashing behaviour of module import on missing template file.

imho, just importing module should have no side effects.

this is how it hit us:
1) our program structure is roughly like this:
```
import migration

def main():
  init_logging_system_so_that_is_catches_crashes_to_file()
  do_migration()

main()
```
2) the template.txt file is missing
3) on a headless system (which discards all stderr and stdout) we try to run the program
3) it crashes "silently" without logging any error
4) ...minutes and minutes finding what the hell is going on :-(

...of course the real system is much more complicated but you get the idea.

cc/ @klen

p.s.: if the template is not supposed to be read over and over, let's just store it somewhere in Router instance