### PR TITLE
fix(logging): don't write to stderr when used as a library

### DIFF
--- a/peewee_migrate/__init__.py
+++ b/peewee_migrate/__init__.py
@@ -16,8 +16,7 @@ __license__ = "BSD"
 
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
-LOGGER.addHandler(logging.StreamHandler())
-LOGGER.setLevel(logging.INFO)
+LOGGER.addHandler(logging.NullHandler())
 
 
 class MigrateHistory(pw.Model):

--- a/peewee_migrate/cli.py
+++ b/peewee_migrate/cli.py
@@ -1,4 +1,5 @@
 """CLI integration."""
+import logging
 import os
 import re
 import sys
@@ -63,7 +64,7 @@ def get_router(
 @click.group()
 def cli():
     """Just a group."""
-    pass
+    logging.basicConfig(level=logging.INFO)
 
 
 @cli.command()


### PR DESCRIPTION
Let applications that use peewee_migrate to control their output. https://docs.python.org/3/library/logging.handlers.html#nullhandler

Fixes #216

Note: the code just expresses the intent to start the discussion. It may need to be tweaked before the merge.

cc/ @klen
