### PR TITLE
fix: python template for bundling

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -16,6 +16,7 @@ import peewee as pw
 from peewee_migrate import LOGGER, MigrateHistory
 from peewee_migrate.auto import NEWLINE, diff_many
 from peewee_migrate.migrator import Migrator
+from peewee_migrate.template import TEMPLATE
 
 from . import MIGRATE_TABLE
 
@@ -60,12 +61,6 @@ class BaseRouter(object):
         MigrateHistory._meta.schema = self.schema
         MigrateHistory.create_table(True)
         return MigrateHistory
-
-    @cached_property
-    def template(self) -> str:
-        """Return migration template."""
-        with open(Path(__file__).parent / "template.txt") as fp:
-            return fp.read()
 
     @property
     def todo(self) -> t.List[str]:
@@ -276,7 +271,7 @@ class Router(BaseRouter):
         path = os.path.join(self.migrate_dir, filename)
         with open(path, "w") as f:
             f.write(
-                self.template.format(migrate=migrate, rollback=rollback, name=filename)
+                TEMPLATE.format(migrate=migrate, rollback=rollback, name=filename)
             )
 
         return name

--- a/peewee_migrate/template.py
+++ b/peewee_migrate/template.py
@@ -1,4 +1,5 @@
-"""Peewee migrations -- {name}.
+TEMPLATE = """\
+\"\"\"Peewee migrations -- {name}.
 
 Some examples (model - class or model name)::
 
@@ -19,26 +20,27 @@ Some examples (model - class or model name)::
     > migrator.drop_not_null(model, *field_names)
     > migrator.add_default(model, field_name, default)
 
+\"\"\"
+
+# import datetime as dt
+# import peewee as pw
+# from peewee_migrate import Migrator
+# from decimal import ROUND_HALF_EVEN
+
+# try:
+#     import playhouse.postgres_ext as pw_pext
+# except ImportError:
+#     pass
+
+# SQL = pw.SQL
+
+
+# def migrate(migrator: Migrator, database, fake=False, **kwargs):
+#     \"\"\"Write your migrations here.\"\"\"
+# {migrate}
+
+
+# def rollback(migrator: Migrator, database, fake=False, **kwargs):
+#     \"\"\"Write your rollback migrations here.\"\"\"
+# {rollback}
 """
-
-import datetime as dt
-import peewee as pw
-from peewee_migrate import Migrator
-from decimal import ROUND_HALF_EVEN
-
-try:
-    import playhouse.postgres_ext as pw_pext
-except ImportError:
-    pass
-
-SQL = pw.SQL
-
-
-def migrate(migrator: Migrator, database, fake=False, **kwargs):
-    """Write your migrations here."""
-{migrate}
-
-
-def rollback(migrator: Migrator, database, fake=False, **kwargs):
-    """Write your rollback migrations here."""
-{rollback}


### PR DESCRIPTION
Fixes #

When bundling using Nuitka or PyInstaller, the template.txt is not bundled which leads to a runtime error `FileNotFoundError`.

Changes in this PR
- Use a Python file with a constant instead of `template.txt`
- Removed the `template` cached property since it is now a constant

cc/ @klen
