### PR TITLE
fix: typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-Fixes #
+Fixes \#
 
-Changes is in this PR
--
--
+## Changes in this PR
+
+- 
 
 cc/ @klen


### PR DESCRIPTION
Fixes #

Changes is in this PR
- Remove useless "is" above ⬆from the template.

cc/ @klen
