### PR TITLE
Support fields constrains change

### DIFF
--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -123,7 +123,13 @@ class SqliteMigrator(SchemaMigrator, SqM):
 
     def alter_change_column(self, table: str, column: str, field: pw.Field) -> Operation:
         """Support change columns."""
-        return self._update_column(table, column, lambda a, b: b)  # type: ignore[]
+
+        def fn(c_name, c_def):
+            ctx = self.make_context()
+            ctx.sql(field.ddl(ctx))
+            return ctx.query()[0]
+
+        return self._update_column(table, column, fn)  # type: ignore[]
 
 
 class ORM:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from peewee import CharField, ForeignKeyField, IntegerField, Model
+from peewee import CharField, ForeignKeyField, IntegerField, Model, Check
 
 
 class Customer(Model):


### PR DESCRIPTION
After 0.14.0 it's not possible to change field constraint in SQLite using peewee_migrate.

This commit returns 0.14.0 behavior for Migrator.change_fields()

## Changes in this PR
change_field() replaces existing field with new one with the same name
added unit test

- 

cc/ @klen
