### PR TITLE
Add poetry.scripts section to fix missing pw_migrate command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
+[tool.poetry.scripts]
+pw_migrate = "peewee_migrate.cli:cli"
+
 [tool.poetry.dependencies]
 python = "^3.8"
 peewee = "^3"


### PR DESCRIPTION
Fixes #221 

## Changes in this PR

- Add `[tool.poetry.scripts]` section to fix missing `pw_migrate` command

cc/ @klen
