### PR TITLE
fix invalid repr in fields where default is casted

### DIFF
--- a/peewee_migrate/auto.py
+++ b/peewee_migrate/auto.py
@@ -127,7 +127,11 @@ class Column(VanilaColumn):
             params["null"] = self.nullable
 
         if self.field.default is not None and not callable(self.field.default):
-            params["default"] = repr(self.field.db_value(self.field.default))
+            value = self.field.db_value(self.field.default)
+            if isinstance(value, pw.Cast):
+                params["default"] = value.node
+            else:
+                params["default"] = repr(value)
 
         return params
 

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -71,6 +71,7 @@ def test_auto_postgresext():
     class Object(pw.Model):
         array_field = ArrayField()
         binary_json_field = BinaryJSONField()
+        binary_json_field_with_default = BinaryJSONField(default={})
         dattime_tz_field = DateTimeTZField()
         hstore_field = HStoreField()
         interval_field = IntervalField()
@@ -80,6 +81,7 @@ def test_auto_postgresext():
     code = model_to_code(Object)
     assert code
     assert "json_field = pw_pext.JSONField()" in code
+    assert "binary_json_field_with_default = pw_pext.BinaryJSONField(default={}, index=True)" in code
     assert "hstore_field = pw_pext.HStoreField(index=True)" in code
 
 


### PR DESCRIPTION
Fixes \#

if given a field that casts the default the code would have produced unusable migrations, for example this

```py
data = f.BinaryJSONField(default={})
```
would have been converted to
```py
data = pw_pext.BinaryJSONField(default=<peewee.Cast object at 0x7f96a9751850>, index=True)
```
now this is fixed

## Changes in this PR

- 

cc/ @klen
