### PR TITLE
bugfix: removed double creation of unique index

### DIFF
--- a/peewee_migrate/migrator.py
+++ b/peewee_migrate/migrator.py
@@ -169,10 +169,6 @@ class Migrator:
                     meta.table_name, field.column_name, field
                 )
             )
-            if field.unique:
-                self.__ops__.append(
-                    self.__migrator__.add_index(meta.table_name, (field.column_name,), unique=True)
-                )
         return model
 
     add_columns = depricated_method(add_fields, "add_columns")


### PR DESCRIPTION
## Changes in this PR

- removing of double unique index creation, as it is already created in playhouse - https://github.com/coleifer/peewee/blame/f107a90897a21c9e4ef1aa43bd61a54ceb5e943f/playhouse/migrate.py#L345
- without this commit the behavior is:
```
2023-08-04 11:53:51,517 20748 9968 N/A INFO peewee_migrate Migrate "123_add_uuid"
2023-08-04 11:53:51,517 20748 9968 N/A INFO peewee_migrate add_column ('some_table', 'uuid', <SomeField: SomeModel.uuid>)
2023-08-04 11:53:51,517 20748 9968 N/A DEBUG peewee ('ALTER TABLE `some_table` ADD COLUMN `uuid` BINARY(16)', [])
2023-08-04 11:53:51,521 20748 9968 N/A DEBUG peewee ('CREATE UNIQUE INDEX `some_table_uuid` ON `some_table` (`uuid`)', [])
2023-08-04 11:53:51,528 20748 9968 N/A INFO peewee_migrate add_index ('some_table', ('uuid',))
2023-08-04 11:53:51,528 20748 9968 N/A DEBUG peewee ('CREATE UNIQUE INDEX `some_table_uuid` ON `some_table` (`uuid`)', [])
...
pymysql.err.OperationalError: (1061, "Duplicate key name 'some_table_uuid'")
```

cc/ @klen
