### PR TITLE
Specify utf-8 encoding when writing a file in router.py

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -280,7 +280,7 @@ class Router(BaseRouter):
         name = "{:03}_".format(num + 1) + name
         filename = name + ".py"
         path = self.migrate_dir / filename
-        with path.open("w") as f:
+        with path.open("w", encoding="utf-8") as f:
             f.write(TEMPLATE.format(migrate=migrate, rollback=rollback, name=filename))
 
         return name


### PR DESCRIPTION
Without specifying "utf-8" encoding when writing a file the script fails to write text to a file in many cases. 

I can't say if it's specific to OS region\language or contents of the file, but this simple change fixes any such issues.

## Changes in this PR

Add `encoding="utf-8"` to the file open on write. 

cc/ @klen
